### PR TITLE
Add Braid Health DICOM Viewer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,7 @@ The [DICOM Standard](https://www.dicomstandard.org/) is _the_ international stan
 - [dcmjs-imaging](https://github.com/PantelisGeorgiadis/dcmjs-imaging) - DICOM image and overlay rendering pipeline for Node.js and browser using the dcmjs library.
 - [dcmjs-ecg](https://github.com/PantelisGeorgiadis/dcmjs-ecg) - DICOM electrocardiography (ECG) rendering for Node.js and browser using dcmjs.
 - [dicom.ts](https://github.com/wearemothership/dicom.ts) - A small, superfast JS DICOM renderer.
+- [Braid Health DICOM Viewer](https://braid.health/www/free-dicom-viewer) - Free FDA 510(k)-cleared DICOM viewer with patented 3D volumetric rendering at 60fps in the browser. Touch-friendly on mobile, built-in AI analysis, and integrated radiologist network for second opinions. No download or account required.
 - [dicom-microscopy-viewer](https://github.com/ImagingDataCommons/dicom-microscopy-viewer) - Vanilla JS library for web-based visualization of DICOM VL Whole Slide Microscopy Image datasets and derived information.
 - [dicomviewer](https://github.com/ayselafsar/dicomviewer) - A DICOM viewer which uses the cornerstone.js library to display DICOM files in Nextcloud.
 - [dicomViewerLib](https://github.com/fourctv/dicomViewerLib) - An Angular 9+ DICOMWeb viewer component, based on the cornerstone.js project.


### PR DESCRIPTION
Adds Braid Health's free FDA-cleared DICOM viewer to the JavaScript > Visualization section.

Key differentiators from existing entries:
- Only FDA 510(k)-cleared free viewer on this list
- Patented volumetric 3D rendering at 60fps in browser (no plugin)
- Built-in agentic AI for scan analysis
- Integrated radiologist network for second opinions
- Touch-friendly on all devices including mobile
- No download, installation, or account required

Live at: https://braid.health/www/free-dicom-viewer