### PR TITLE
Add dcm-anon to Python anonymization tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,7 @@ The [DICOM Standard](https://www.dicomstandard.org/) is _the_ international stan
 
 #### Anonymization
 
+- [dcm-anon](https://github.com/Ces107/dcm-anon) - PS3.15 Basic Profile anonymizer that emits a hash-chained GDPR/HIPAA compliance manifest and an independent post-run residual-PHI scan.
 - [deid](https://github.com/pydicom/deid) - Best effort anonymization for medical images in Python.
 - [DICAT](https://github.com/aces/DICAT) - A simple graphical tool that facilitates DICOM de-identification directly on a local workstation.
 - [dicom-anonymizer](https://github.com/KitwareMedical/dicom-anonymizer) - A tool for anonymizing DICOM files according to the DICOM standard.


### PR DESCRIPTION
Adds [dcm-anon](https://github.com/Ces107/dcm-anon) to the Python > Anonymization section.

What it is: a Python CLI implementing PS3.15 Basic Application Level Confidentiality Profile (143 tags, 2024 edition; mandatory Basic Profile plus retired tags and original-attributes audit trail). Single runtime dependency (pydicom>=2.4), MIT.

What it adds beyond the three tools already listed:

- Emits a verbatim-cited compliance manifest (GDPR Art. 9 + Art. 35, HIPAA Safe Harbor, EU AI Act) that maps every PS3.15 X/Z/U/D action to the specific clause that authorises it. SHA-256 chained against the per-tag audit so an auditor can verify integrity from the JSON alone.
- Runs an independent residual-PHI scan after the run using a separate tag list (HIPAA Safe Harbor 164.514(b)(2) + TCIA checklist, not derived from the internal table). Defeats the tool-vouches-for-itself failure mode.

Entry placed alphabetically inside the existing Python > Anonymization subsection. Description matches the sentence style of the other three entries.

PyPI: https://pypi.org/project/dcm-anonymizer/ (distribution name differs from CLI name due to a similar-name collision with pre-existing dcmanon; a PEP 541 claim is pending).
DOI: https://doi.org/10.5281/zenodo.20267651
License: MIT

Disclosure: I am the author. Happy to revise wording or placement if it does not fit the list's editorial line.