### PR TITLE
Add Dicom Viewer (native iOS DICOM viewer)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -197,6 +197,7 @@ The [DICOM Standard](https://www.dicomstandard.org/) is _the_ international stan
 #### Visualization
 
 - [AlizaMS](https://github.com/AlizaMedicalImaging/AlizaMS) - DICOM viewer.
+- [Dicom Viewer](https://github.com/EdCafferata/DICOM-player) - Native iOS (SwiftUI) DICOM viewer for iPhone and iPad, with a custom DICOM parser and no external dependencies. On-device only: no account, no cloud upload, no PACS connection. Includes a cine player, Window/Level presets, series navigator and frame export. [App Store](https://apps.apple.com/us/app/dicom-viewer-by-the-it-crowd/id1483496527).
 
 #### Image Computing Platforms
 


### PR DESCRIPTION
Adds Dicom Viewer to the Visualization section under Other/Combination.

Dicom Viewer is a native iOS (SwiftUI) DICOM viewer for iPhone/iPad, open source under
GPL-3.0, with a custom DICOM parser and no external dependencies. It runs entirely
on-device: no account, no cloud upload, no PACS connection. Features include a cine
player for multi-frame studies, Window/Level presets (Abdomen, Lung, Bone, Brain), a
series navigator, and frame export to PNG/JPEG.

- Repo: https://github.com/EdCafferata/DICOM-player (GPL-3.0, actively maintained)
- App Store: https://apps.apple.com/us/app/dicom-viewer-by-the-it-crowd/id1483496527